### PR TITLE
Get Those Printer Capabilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,16 @@ Example::
 
 Change log
 ==========
+0.3.4
+=====
+
+- Adds printer capabilities method
+- Migrates to use ticket (CJT) over deprecated capabilities
+
+0.3.3
+=====
+
+- Adds improvements for URL based content
 
 0.3.2
 =====

--- a/cloudprinting/__init__.py
+++ b/cloudprinting/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.4"
+__version__ = "0.3.3"
 
 from .auth import OAuth2
 try:

--- a/cloudprinting/__init__.py
+++ b/cloudprinting/__init__.py
@@ -1,8 +1,8 @@
-__version__ = "0.3.2"
+__version__ = "0.3.4"
 
 from .auth import OAuth2
 try:
     from .auth import ClientLoginAuth
 except ImportError:
     pass
-from .client import delete_job, get_job, list_jobs, list_printers, submit_job
+from .client import delete_job, get_job, list_jobs, list_printers, submit_job, get_printer

--- a/cloudprinting/client.py
+++ b/cloudprinting/client.py
@@ -12,7 +12,7 @@ def get_printer(id, **kwargs):
     Returns all of the fields of the specified printer, including its
     capabilities.
 
-    :param      id: printer ID
+    :param     id: printer ID
     :type       id: string
     """
     url = CLOUDPRINT_URL + "/printer"
@@ -102,7 +102,7 @@ def list_printers(**kwargs):
     return r.json()
 
 
-def submit_job(printer, content, title=None, capabilities=None, tags=None,
+def submit_job(printer, content, title=None, ticket=None, tags=None,
                content_type=None, **kwargs):
     """
     Submit a print job.
@@ -111,8 +111,8 @@ def submit_job(printer, content, title=None, capabilities=None, tags=None,
     :type        printer: string
     :param       content: what should be printer
     :type        content: ``(name, file-like)`` pair or path
-    :param  capabilities: capabilities for the printer
-    :type   capabilities: list
+    :param        ticket: CJT "ticket" for the printer
+    :type         ticket: list
     :param         title: title of the print job, should be unique to printer
     :type          title: string
     :param          tags: job tags
@@ -144,15 +144,15 @@ def submit_job(printer, content, title=None, capabilities=None, tags=None,
     if title is None:
         title = name
 
-    if capabilities is None:
+    if ticket is None:
         # magic default value
-        capabilities = [{}]
+        ticket = [{}]
 
     data = {
         "printerid": printer,
         "title": title,
         "contentType": content_type or mimetypes.guess_type(name)[0],
-        "capabilities": json.dumps({"capabilities": capabilities}),
+        "ticket": json.dumps(ticket),
     }
 
     if tags:

--- a/cloudprinting/client.py
+++ b/cloudprinting/client.py
@@ -4,8 +4,23 @@ import mimetypes
 from os.path import basename
 import requests
 
-
 CLOUDPRINT_URL = "https://www.google.com/cloudprint"
+
+
+def get_printer(id, **kwargs):
+    """
+    Returns all of the fields of the specified printer, including its
+    capabilities.
+
+    :param      id: printer ID
+    :type       id: string
+    """
+    url = CLOUDPRINT_URL + "/printer"
+    params = {'printerid': id}
+    r = requests.post(url, params=params, **kwargs)
+    if r.status_code != requests.codes.ok:
+        return r
+    return r.json()
 
 
 def get_job(id, printer=None, **kwargs):


### PR DESCRIPTION
Ands `get_printer` method that retrieves all of the fields of the specified printer, including its capabilities.  Also migrates from the deprecated `capabilities` in favor of the ticket ([CJT](https://developers.google.com/cloud-print/docs/cdd#cjt)) parameter.